### PR TITLE
[AUDIT FIX] Add tokenOut check to UniswapV3Adapter

### DIFF
--- a/.changeset/healthy-pillows-fold.md
+++ b/.changeset/healthy-pillows-fold.md
@@ -1,0 +1,5 @@
+---
+"@nocturne-xyz/contracts": patch
+---
+
+Add tokenOut check for exactInputSingle in UniswapV3Adapter

--- a/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
+++ b/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
@@ -40,7 +40,7 @@ contract UniswapV3Adapter is Ownable {
         emit TokenPermissionSet(token, permission);
     }
 
-    /// @notice Proxy for exactInputSingle function of Uniswap SwapRouter. Ensures tokenIn and 
+    /// @notice Proxy for exactInputSingle function of Uniswap SwapRouter. Ensures tokenIn and
     ///         tokenOut are allowed and recipient is caller.
     /// @param params ExactInputSingleParams (see ISwapRouter)
     function exactInputSingle(

--- a/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
+++ b/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
@@ -46,7 +46,8 @@ contract UniswapV3Adapter is Ownable {
     function exactInputSingle(
         ISwapRouter.ExactInputSingleParams memory params
     ) external returns (uint256 amountOut) {
-        require(_allowedTokens[params.tokenIn], "!allowed token");
+        require(_allowedTokens[params.tokenIn], "!tokenIn");
+        require(_allowedTokens[params.tokenOut], "!tokenOut");
         require(params.recipient == msg.sender, "!recipient");
 
         IERC20(params.tokenIn).transferFrom(

--- a/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
+++ b/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
@@ -40,8 +40,8 @@ contract UniswapV3Adapter is Ownable {
         emit TokenPermissionSet(token, permission);
     }
 
-    /// @notice Proxy for exactInputSingle function of Uniswap SwapRouter. Ensures tokenIn
-    ///         is allowed and recipient is caller.
+    /// @notice Proxy for exactInputSingle function of Uniswap SwapRouter. Ensures tokenIn and 
+    ///         tokenOut are allowed and recipient is caller.
     /// @param params ExactInputSingleParams (see ISwapRouter)
     function exactInputSingle(
         ISwapRouter.ExactInputSingleParams memory params


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation
exactInputSingle needs to validate output token too for 3.1 and 3.2.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- add tokenOut check to exactInputSingle method in adapter
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Proof

<!--
If features/changes is hard to test e2e, include a video or image proving you've
tested your solution and it works.
-->

## PR Checklist

- [ ] added tests
- [x] updated documentation
- [x] added changeset if necessary
- [ ] tested in dev/testnet
- [ ] tested site with snap (we haven't automated this yet)
- [ ] re-built & tested circuits if any of them changed
- [ ] updated contracts storage layout (if contracts were updated)
