### PR TITLE
Add missing `ReentrancyGuard__init` in DepositManager

### DIFF
--- a/.changeset/afraid-elephants-build.md
+++ b/.changeset/afraid-elephants-build.md
@@ -1,0 +1,5 @@
+---
+"@nocturne-xyz/contracts": patch
+---
+
+initialize ReentrancyGuard upgradeable in DepositManager initialization function

--- a/packages/contracts/contracts/DepositManager.sol
+++ b/packages/contracts/contracts/DepositManager.sol
@@ -108,6 +108,7 @@ contract DepositManager is
         address weth
     ) external initializer {
         __Ownable2Step_init();
+        __ReentrancyGuard_init();
         __DepositRequestEIP712_init(contractName, contractVersion);
         _teller = ITeller(teller);
         _weth = IWeth(weth);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation
Was reviewing deploy script, realized this DepositManger reentrancy guard initialization was missing.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- add the reentrancy guard init function call in DepositManager `initialize`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Proof

<!--
If features/changes is hard to test e2e, include a video or image proving you've
tested your solution and it works.
-->

## PR Checklist

- [ ] added tests
- [ ] updated documentation
- [x] added changeset if necessary
- [ ] tested in dev/testnet
- [ ] tested site with snap (we haven't automated this yet)
- [ ] re-built & tested circuits if any of them changed
- [ ] updated contracts storage layout (if contracts were updated)
