### PR TITLE
dont restrict uniswap recipient

### DIFF
--- a/.changeset/giant-spoons-poke.md
+++ b/.changeset/giant-spoons-poke.md
@@ -1,0 +1,5 @@
+---
+"@nocturne-xyz/contracts": patch
+---
+
+don't restrict recipient of uniswap adapter to allow swap outputs to fresh addresses

--- a/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
+++ b/packages/contracts/contracts/adapters/UniswapV3Adapter.sol
@@ -41,14 +41,13 @@ contract UniswapV3Adapter is Ownable {
     }
 
     /// @notice Proxy for exactInputSingle function of Uniswap SwapRouter. Ensures tokenIn and
-    ///         tokenOut are allowed and recipient is caller.
+    ///         tokenOut are allowed.
     /// @param params ExactInputSingleParams (see ISwapRouter)
     function exactInputSingle(
         ISwapRouter.ExactInputSingleParams memory params
     ) external returns (uint256 amountOut) {
         require(_allowedTokens[params.tokenIn], "!tokenIn");
         require(_allowedTokens[params.tokenOut], "!tokenOut");
-        require(params.recipient == msg.sender, "!recipient");
 
         IERC20(params.tokenIn).transferFrom(
             address(msg.sender),
@@ -61,13 +60,12 @@ contract UniswapV3Adapter is Ownable {
     }
 
     /// @notice Proxy for exactInput function of Uniswap SwapRouter.
-    ///         Ensures all tokens in path are is allowed and recipient is caller.
+    ///         Ensures all tokens in path are is allowed.
     /// @param params ExactInputParams (see ISwapRouter)
     function exactInput(
         ISwapRouter.ExactInputParams memory params
     ) external returns (uint256 amountOut) {
         require(tokensAreAllowed(params.path), "!allowed path");
-        require(params.recipient == msg.sender, "!recipient");
 
         address tokenIn = extractTokenAddressFromPath(params.path, 0);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation
Want to allow user to swap and send in same action (e.g. send DAI by swapping from ETH).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- remove recipient check from UniswapAdapter
- NOTE: this is reentrancy safe still because tokens sent must be whitelisted erc20 tokens and will come out via transfer call
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Proof

<!--
If features/changes is hard to test e2e, include a video or image proving you've
tested your solution and it works.
-->

## PR Checklist

- [ ] added tests
- [x] updated documentation
- [x] added changeset if necessary
- [ ] tested in dev/testnet
- [ ] tested site with snap (we haven't automated this yet)
- [ ] re-built & tested circuits if any of them changed
- [ ] updated contracts storage layout (if contracts were updated)
